### PR TITLE
QA-8557

### DIFF
--- a/war/src/main/webapp/WEB-INF/etc/repository/nodetypes/02-jahia-nodetypes.cnd
+++ b/war/src/main/webapp/WEB-INF/etc/repository/nodetypes/02-jahia-nodetypes.cnd
@@ -951,7 +951,7 @@ extends = jnt:content
  - j:mixinExtends (string,choicelist[nodetypes='PRIMARY;fromDependencies;useName']) multiple
 
 [jnt:primaryNodeType] > jnt:nodeType
- - j:supertype (NAME,choicelist[nodetypes='PRIMARY;fromDependencies;useName'])
+ - j:supertype (NAME,choicelist[nodetypes='PRIMARY;fromDependencies;useName']) = 'jnt:content' 
  - j:mixins (NAME,choicelist[nodetypes='MIXIN;fromDependencies;useName']) multiple
  - j:isAbstract (BOOLEAN) mandatory
  - j:isQueryable (BOOLEAN) = true mandatory


### PR DESCRIPTION
When creating a new content type in the Studio, preselect "jnt:content" as supertype