### PR TITLE
fix issue where only the last script of a view is loaded on .ajax request

### DIFF
--- a/core/src/main/java/org/jahia/services/render/filter/StaticAssetsFilter.java
+++ b/core/src/main/java/org/jahia/services/render/filter/StaticAssetsFilter.java
@@ -257,7 +257,7 @@ public class StaticAssetsFilter extends AbstractFilter implements ApplicationLis
         OutputDocument outputDocument = new OutputDocument(source);
 
         if (renderContext.isAjaxRequest()) {
-            out = renderAjaxStaticAssets(previousOut, renderContext, resource, out, source, outputDocument, assetsByTarget);
+            out = renderAjaxStaticAssets(renderContext, resource, out, source, outputDocument, assetsByTarget);
         } else if (resource.getContextConfiguration().equals("page")) {
             out = renderPageStaticAssets(renderContext, resource, source, outputDocument, assetsByTarget);
         }
@@ -343,7 +343,7 @@ public class StaticAssetsFilter extends AbstractFilter implements ApplicationLis
         assets.put(type, stringMap);
     }
 
-    private String renderAjaxStaticAssets(String previousOut, RenderContext renderContext,
+    private String renderAjaxStaticAssets(RenderContext renderContext,
             org.jahia.services.render.Resource resource, String out, Source source, OutputDocument outputDocument,
             Map<String, Map<String, Map<String, Map<String, String>>>> assetsByTarget) throws IOException, ScriptException {
 
@@ -374,7 +374,7 @@ public class StaticAssetsFilter extends AbstractFilter implements ApplicationLis
                     outputDocument.replace(tag.getBegin(), tag.getBegin() + 1, "\n" + staticsAsset + "\n<");
                     out = outputDocument.toString();
                 } else {
-                    out = staticsAsset + "\n" + previousOut;
+                    out = staticsAsset + "\n" + out;
                 }
             }
         }


### PR DESCRIPTION
## Description
I believe the wrong variable was used here, unless there is an use case I don't see.

So with `previousOut` if there are multiple scripts on a view, let say a CSS and a JS for example and no `target` property on the `<template:addResources` only the last script is added to `out` since `out` is overwritten on each loop by the script + previousOut.
Using `out` which is initialized with `previousOut` there is no more issue, all the scripts are correctly loaded.