### PR TITLE
BACKLOG-22667: add parameters to mssql-url

### DIFF
--- a/docker/docker-jahia-core/bin/entrypoint.sh
+++ b/docker/docker-jahia-core/bin/entrypoint.sh
@@ -67,7 +67,7 @@ if [ ! -f "/usr/local/tomcat/conf/configured" ]; then
               ;;
           "mssql")
               DB_PORT=${DB_PORT:-1433}
-              DB_URL="jdbc:sqlserver://${DB_HOST}:${DB_PORT};databaseName=${DB_NAME}"
+              DB_URL="jdbc:sqlserver://${DB_HOST}:${DB_PORT};databaseName=${DB_NAME};integratedSecurity=false;encrypt=false;trustServerCertificate=false"
               ;;
           "oracle")
               DB_PORT=${DB_PORT:-1521}


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-22667: add parameters to mssql-url
[https://support.jahia.com/browse/INFRA-2864](https://support.jahia.com/browse/INFRA-2864?focusedId=308871&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-308871)

## Description
Following the DB-valdiation test we had to add some parameters to the mssql url to make it work for MSSQL 22
Adding them to docker also, as currently I am seeing the same errors in the logs there.
<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
