### PR TITLE
BACKLOG-23291: update copyright year in the administration

### DIFF
--- a/core/src/test/java/org/jahia/utils/comparator/VersionComparatorTest.java
+++ b/core/src/test/java/org/jahia/utils/comparator/VersionComparatorTest.java
@@ -58,7 +58,7 @@ import static org.junit.Assert.*;
  * JAHIA'S ENTERPRISE DISTRIBUTIONS LICENSING - IMPORTANT INFORMATION
  * ==========================================================================================
  *
- *     Copyright (C) 2002-2023 Jahia Solutions Group. All rights reserved.
+ *     Copyright (C) 2002-2025 Jahia Solutions Group. All rights reserved.
  *
  *     This file is part of a Jahia's Enterprise Distribution.
  *


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/BACKLOG-23291

## Description

Updated copyright year in the license displayed in the administration > license > Jahia license.